### PR TITLE
Reintroduce 'become' flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ boom deploy -t shell/zsh
 
 # Deploy multiple topics
 boom deploy -t shell/zsh,shell/git,editor/vscode
+
+# Deploy with escalated priveleges (tell ansible to prompt for sudo password)
+boom deploy -b
 ```
 
 #### Operations

--- a/src/commands/runPlaybook.ts
+++ b/src/commands/runPlaybook.ts
@@ -9,10 +9,7 @@ import { pacmanEntry } from '../constants/flagToTagMap'
 export default async function runPlaybook(settings: Settings, argv: any) {
   const { provisionDir, deployScript } = settings
   let ansibleTags = buildTags(argv.operations)
-  if (pacmanWillBeCalled(argv)) {
-    argv.verbose = true
-    log.info(`Running in verbose mode to support pacman`)
-  }
+  if (pacmanWillBeCalled(argv)) argv.become = true
   let ansibleFlags = argv.become ? ' --ask-become-pass' : ''
   if (argv.become) argv.verbose = true
   ansibleFlags += ` --extra-vars \"{is_interactive: ${

--- a/src/index.ts
+++ b/src/index.ts
@@ -116,6 +116,11 @@ const settings: Settings = loadSettings([
           describe: 'list available operations',
           type: 'boolean',
         })
+        yargs.option('become', {
+          alias: 'b',
+          describe: 'elevate privileges (use sudo)',
+          type: 'boolean',
+        })
       },
       async (argv) => {
         if (argv['list-operations']) {


### PR DESCRIPTION
There is still some inconsistent behaviour when running with the `--become` flag and deploying a topic which declares `become: true`.
